### PR TITLE
vendor third-party ansible roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.retry
+vendor/*

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ./vendor/


### PR DESCRIPTION
By default ansible-galaxy installs all roles in a single global location. If you use ansible a lot, this can lead to a situation where you have a conflict because one project requires version X of a dependency and another requires version Y.
I usually guard against this by setting each of my ansible projects up to install dependencies in a local vendor directory inside the project like this.