### PR TITLE
create python manifest, require jmespath

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ worldPing has to be [enabled manually](https://grafana.com/plugins/raintank-worl
 
 ### How to use it?
 
-1. Install Ansible ([doc](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html))
+1. Install python dependencies in a python 3 virtual environment:
+```bash
+pip install -r requirements.txt
+```
 2. Prepare an inventory file `inventory.ini`:
 ```ini
 metrics ansible_host=metrics.example.com ansible_port=22 ansible_user=ubuntu ansible_python_interpreter=/usr/bin/python3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ansible==2.9.10
+jmespath==0.10.0


### PR DESCRIPTION
I tried running this in a completely clean virtual environment with only ansible installed. Provision was failing with:

```
TASK [cloudalchemy.prometheus : Get all file_sd files from scrape_configs] *****
fatal: [metrics]: FAILED! => {"msg": "You need to install \"jmespath\" prior to running json_query filter"}
```

because `jmespath` was not installed.

Lets add a `requirements.txt` to specify required python packages.