### PR TITLE
gitignore vagrant files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *.retry
+
+# Vagrant files
+.vagrant
+roles/*
+ubuntu-bionic-18.04-cloudimg-console.log


### PR DESCRIPTION
Running `vagrant up` creates these files in the repo dir. I don't think we want to commit these.